### PR TITLE
Readme: explained hotkey and linked to blog post

### DIFF
--- a/mysign.py
+++ b/mysign.py
@@ -45,9 +45,10 @@ class MySign:
 				method_file_location = method_obj.filename();
 				autocomplete_list.append((method_str_to_append + '\t' + method_file_location,method_str_to_append)) 
 		return autocomplete_list
-	def get_lang(self, filename):
-		if '.js' in filename:
-			return "javascript"
+
+
+def is_javascript_file(self, filename):
+	return '.js' in filename
 
 #
 # MySign Collector Thread
@@ -119,8 +120,7 @@ class MySignCollector(MySign, sublime_plugin.EventListener):
 	def on_query_completions(self, view, prefix, locations):
 		current_file = view.file_name()
 		completions = []
-		if self.get_lang(current_file) == 'javascript':
-			completions = self.get_autocomplete_list(prefix)
-			completions = list(set(completions))
+		if is_javascript_file(current_file):
+			return = self.get_autocomplete_list(prefix
 			completions.sort()
 		return (completions,sublime.INHIBIT_EXPLICIT_COMPLETIONS)

--- a/readme.md
+++ b/readme.md
@@ -5,9 +5,11 @@ MySignature plugin is very lightweight plugin for sublime which improve the subl
 
 Each method in the autocomplete pop-up box is presented with its signature (method name and arguments) using SublimeText's "auto_complete" box. (You can usually make this box show up with Ctrl+Space.)
 
+This plugin works on save: when you save any file in your project, the plugin maps all your javascript methods of the form `var name = function() {}` and `name: function() {}`. When the complete box is opened (ctrl+space or by the editor), it shows the methods in your project files with the signature. (It currently does not support minified files since the method used is a line-by-line search.)
+
 This plugin is for Javascript Developers only.
 
-Please read more about the plugin and its development at http://www.eladyarkoni.com/2012/09/sublime-text-auto-complete-plugin.html
+Please read more about the plugin and its development at http://www.eladyarkoni.com/2012/09/sublime-text-auto-complete-plugin.html. 
 
 Enjoy!
 

--- a/readme.md
+++ b/readme.md
@@ -3,9 +3,11 @@ MySignature - Sublime text 2 plugin
 
 MySignature plugin is very lightweight plugin for sublime which improve the sublime text autocomplete functionality.
 
-Each method in the autocomplete pop-up box is presented with its signature (method name and arguments)
+Each method in the autocomplete pop-up box is presented with its signature (method name and arguments) using SublimeText's "auto_complete" box. (You can usually make this box show up with Ctrl+Space.)
 
 This plugin is for Javascript Developers only.
+
+Please read more about the plugin and its development at http://www.eladyarkoni.com/2012/09/sublime-text-auto-complete-plugin.html
 
 Enjoy!
 


### PR DESCRIPTION
Elad, I think the blog post would be useful for others, so I added it to the readme. Also, I think it's useful to point out how the autocomplete list is invoked, for those who don't know or are not sure if the plugin uses some other hotkey.

Unfortunately, I'm still experiencing problems with the plugin, but maybe I'll put some effort into debugging it.
